### PR TITLE
feat: 코드 블록 복사 버튼 추가 및 스크립트 정적 파일로 이전

### DIFF
--- a/public/scripts/copy-code.js
+++ b/public/scripts/copy-code.js
@@ -1,0 +1,42 @@
+// 전체 페이지의 <pre><code> 블록에 복사 버튼 붙이기
+document.addEventListener('DOMContentLoaded', () => {
+  const pres = document.querySelectorAll('pre');
+
+  pres.forEach((pre) => {
+    if (pre.querySelector('.copy-btn')) return; // 중복 방지
+    const code = pre.querySelector('code');
+    if (!code) return;
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'copy-btn';
+    btn.setAttribute('aria-label', '코드 복사');
+    btn.textContent = 'Copy';
+
+    const preStyle = getComputedStyle(pre);
+    if (preStyle.position === 'static') {
+      pre.style.position = 'relative';
+    }
+
+    btn.addEventListener('click', async () => {
+      const text = code.innerText;
+      try {
+        await navigator.clipboard.writeText(text);
+        const original = btn.textContent;
+        btn.textContent = 'Copied!';
+        btn.classList.add('copied');
+        setTimeout(() => {
+          btn.textContent = original || 'Copy';
+          btn.classList.remove('copied');
+        }, 1500);
+      } catch {
+        const original = btn.textContent;
+        btn.textContent = 'Error';
+        setTimeout(() => (btn.textContent = original || 'Copy'), 1200);
+      }
+    });
+
+    pre.appendChild(btn);
+  });
+});
+

--- a/src/content/posts/hello-zenn.mdx
+++ b/src/content/posts/hello-zenn.mdx
@@ -15,3 +15,10 @@ description: "Astro+MDX 기반의 Zenn 스타일 미니 블로그 시작 기록"
 - 사이드 목차 자동 생성
 - 깔끔한 타이포그래피
 
+## 코드 블록 지원!
+```bash
+pnpm create astro@latest my-blog
+cd my-blog
+pnpm install
+pnpm dev
+```

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,6 +11,9 @@ const { title = "Astroxx Blog", description = "Zenn 스타일의 미니 블로�
     <main class="prose prose-neutral mx-auto px-4 py-8">
       <slot />
     </main>
+
+    <!-- 코드 복사 버튼 스크립트 -->
+    <script type="module" src={Astro.base + 'scripts/copy-code.js'}></script>
   </body>
 </html>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,3 +11,35 @@ body {
 .prose :where(h1,h2,h3,h4){ scroll-margin-top: 96px; }
 .prose :where(a){ text-decoration: none; }
 .prose :where(a:hover){ text-decoration: underline; }
+
+/* Copy button for code blocks */
+pre .copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+
+  font-size: 12px;
+  line-height: 1;
+  padding: 6px 10px;
+
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  opacity: 0.0;
+  transition: opacity .15s ease, transform .05s ease, background .15s ease;
+}
+
+pre:hover .copy-btn {
+  opacity: 1;
+}
+
+pre .copy-btn:active {
+  transform: translateY(1px);
+}
+
+pre .copy-btn.copied {
+  background: rgba(16, 185, 129, 0.9); /* emerald-ish */
+}
+


### PR DESCRIPTION
- 코드 블록에 Copy 버튼 자동 생성 기능 추가
- src/scripts/copy-code.ts → public/scripts/copy-code.js 로 이동\n- BaseLayout.astro에서 정적 경로(Astro.base + ...)로 로드하도록 변경
- global.css에 버튼 스타일 정의